### PR TITLE
Add Muscle Beach Classic blog entry

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -70,9 +70,16 @@
     <ul class="mt-8 space-y-6">
       <li class="rounded-2xl border border-slate-200 p-6 bg-white">
         <h2 class="text-2xl font-bold">
+          <a class="hover:text-pink-600" href="/blog/muscle-beach-classic-galveston-2025.html">See You at the Muscle Beach Classic — Galveston, Oct 4!</a>
+        </h2>
+        <p class="mt-2 text-slate-700">We’re sponsoring the Muscle Beach Classic and bringing competitor-focused waxing tips and product picks to Galveston.</p>
+        <p class="mt-2 text-sm text-slate-500">Published Sept 21, 2025</p>
+      </li>
+      <li class="rounded-2xl border border-slate-200 p-6 bg-white">
+        <h2 class="text-2xl font-bold">
           <a class="hover:text-pink-600" href="/blog/summer-shredding-2025.html">Viva La Beauty Sponsors Summer Shredding Houston at Alphaland</a>
         </h2>
-        <p class="mt-2 text-slate-700">Details on the SSC Bash, why waxing benefits athletes & bodybuilders, and how to book.</p>
+        <p class="mt-2 text-slate-700">Details on the SSC Bash, why waxing benefits athletes &amp; bodybuilders, and how to book.</p>
         <p class="mt-2 text-sm text-slate-500">Published Sept 14, 2025</p>
       </li>
     </ul>

--- a/blog/muscle-beach-classic-galveston-2025.html
+++ b/blog/muscle-beach-classic-galveston-2025.html
@@ -62,7 +62,7 @@
         <div class="meta">By Viva La Beauty • Posted September 21, 2025 • <span class="tag">Events</span><span class="tag">Bodybuilding</span><span class="tag">Skin Care</span></div>
         <div class="hero">
           <!-- Replace the src with your event banner if available -->
-          <img src="/assets/blog/muscle-beach-classic-galveston-hero.jpg" alt="Viva La Beauty sponsoring the Muscle Beach Classic in Galveston on October 4, 2025">
+          <img src="/assets/viva-logo-regular.png" alt="Viva La Beauty sponsoring the Muscle Beach Classic in Galveston on October 4, 2025">
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- add the Muscle Beach Classic sponsorship blog post provided by the client and ensure the hero image uses an existing asset
- surface the new article on the blog index alongside the Summer Shredding announcement

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68d08b8e0070833299650d90ffb7ff6d